### PR TITLE
FEAT - Relative plugin paths

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 sudo: required
-dist: trusty
+dist: xenial
 
 jdk:
   - openjdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: java
 sudo: required
-dist: xenial
+dist: trusty
 
 jdk:
   - openjdk8
-  - oraclejdk8
   - openjdk9
   - oraclejdk9
   - oraclejdk11

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ sudo: required
 dist: trusty
 
 jdk:
-  - openjdk7
   - openjdk8
-  - oraclejdk7
   - oraclejdk8
+  - openjdk9
+  - oraclejdk9
 
 branches:
   except:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ jdk:
   - oraclejdk8
   - openjdk9
   - oraclejdk9
+  - oraclejdk11
 
 branches:
   except:

--- a/embeddedfileSample-plugin/pom.xml
+++ b/embeddedfileSample-plugin/pom.xml
@@ -16,6 +16,21 @@
       <groupId>org.verapdf</groupId>
       <artifactId>core</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-core</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/fontSample-plugin/pom.xml
+++ b/fontSample-plugin/pom.xml
@@ -16,6 +16,21 @@
       <groupId>org.verapdf</groupId>
       <artifactId>core</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-core</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/iccprofileSample-plugin/pom.xml
+++ b/iccprofileSample-plugin/pom.xml
@@ -15,6 +15,21 @@
       <groupId>org.verapdf</groupId>
       <artifactId>core</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-core</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/imageSample-plugin/pom.xml
+++ b/imageSample-plugin/pom.xml
@@ -16,6 +16,21 @@
             <groupId>org.verapdf</groupId>
             <artifactId>core</artifactId>
         </dependency>
+
+        <dependency>
+          <groupId>javax.xml.bind</groupId>
+          <artifactId>jaxb-api</artifactId>
+        </dependency>
+
+        <dependency>
+          <groupId>com.sun.xml.bind</groupId>
+          <artifactId>jaxb-impl</artifactId>
+        </dependency>
+
+        <dependency>
+          <groupId>com.sun.xml.bind</groupId>
+          <artifactId>jaxb-core</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/jpylyzer-plugin/pom.xml
+++ b/jpylyzer-plugin/pom.xml
@@ -15,6 +15,21 @@
         <dependency>
             <groupId>org.verapdf</groupId>
             <artifactId>core</artifactId>
+
+        </dependency>
+        <dependency>
+          <groupId>javax.xml.bind</groupId>
+          <artifactId>jaxb-api</artifactId>
+        </dependency>
+
+        <dependency>
+          <groupId>com.sun.xml.bind</groupId>
+          <artifactId>jaxb-impl</artifactId>
+        </dependency>
+
+        <dependency>
+          <groupId>com.sun.xml.bind</groupId>
+          <artifactId>jaxb-core</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/mediaconch/pom.xml
+++ b/mediaconch/pom.xml
@@ -16,6 +16,21 @@
             <groupId>org.verapdf</groupId>
             <artifactId>core</artifactId>
         </dependency>
+
+        <dependency>
+          <groupId>javax.xml.bind</groupId>
+          <artifactId>jaxb-api</artifactId>
+        </dependency>
+
+        <dependency>
+          <groupId>com.sun.xml.bind</groupId>
+          <artifactId>jaxb-impl</artifactId>
+        </dependency>
+
+        <dependency>
+          <groupId>com.sun.xml.bind</groupId>
+          <artifactId>jaxb-core</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/metsMetadata-plugin/pom.xml
+++ b/metsMetadata-plugin/pom.xml
@@ -17,9 +17,25 @@
             <artifactId>mets</artifactId>
             <version>1.0.0</version>
         </dependency>
+
         <dependency>
             <groupId>org.verapdf</groupId>
             <artifactId>core</artifactId>
+        </dependency>
+
+        <dependency>
+          <groupId>javax.xml.bind</groupId>
+          <artifactId>jaxb-api</artifactId>
+        </dependency>
+
+        <dependency>
+          <groupId>com.sun.xml.bind</groupId>
+          <artifactId>jaxb-impl</artifactId>
+        </dependency>
+
+        <dependency>
+          <groupId>com.sun.xml.bind</groupId>
+          <artifactId>jaxb-core</artifactId>
         </dependency>
     </dependencies>
 

--- a/ots-plugin/pom.xml
+++ b/ots-plugin/pom.xml
@@ -16,5 +16,20 @@
             <groupId>org.verapdf</groupId>
             <artifactId>core</artifactId>
         </dependency>
+
+        <dependency>
+          <groupId>javax.xml.bind</groupId>
+          <artifactId>jaxb-api</artifactId>
+        </dependency>
+
+        <dependency>
+          <groupId>com.sun.xml.bind</groupId>
+          <artifactId>jaxb-impl</artifactId>
+        </dependency>
+
+        <dependency>
+          <groupId>com.sun.xml.bind</groupId>
+          <artifactId>jaxb-core</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/plugins/src/main/resources/config/plugins.xml
+++ b/plugins/src/main/resources/config/plugins.xml
@@ -26,36 +26,36 @@
     <name>Font Sample</name>
     <version>${project.version}</version>
     <description>Sample, proof of concept, font plugin. Developed by the veraPDF team.</description>
-    <pluginJar>$INSTALL_PATH/plugins/fontSample-plugin/fontSample-plugin-${project.version}.jar</pluginJar>
+    <pluginJar>plugins/fontSample-plugin/fontSample-plugin-${project.version}.jar</pluginJar>
   </plugin>
   <plugin enabled="false">
     <name>Font Type Sample</name>
     <version>${project.version}</version>
     <description>Sample, proof of concept, font type plugin. Developed by the veraPDF team.</description>
-    <pluginJar>$INSTALL_PATH/plugins/fontType-plugin/fontType-plugin-${project.version}.jar</pluginJar>
+    <pluginJar>plugins/fontType-plugin/fontType-plugin-${project.version}.jar</pluginJar>
   </plugin>
   <plugin enabled="false">
     <name>Embedded File Sample</name>
     <version>${project.version}</version>
     <description>Sample, proof of concept, embedded file plugin. Developed by the veraPDF team.</description>
-    <pluginJar>$INSTALL_PATH/plugins/embeddedfileSample-plugin/embeddedfileSample-plugin-${project.version}.jar</pluginJar>
+    <pluginJar>plugins/embeddedfileSample-plugin/embeddedfileSample-plugin-${project.version}.jar</pluginJar>
   </plugin>
   <plugin enabled="false">
     <name>ICC Profile Sample</name>
     <version>${project.version}</version>
     <description>Sample, proof of concept, ICC Profile plugin. Developed by the veraPDF team.</description>
-    <pluginJar>$INSTALL_PATH/plugins/iccprofileSample-plugin/iccprofileSample-plugin-${project.version}.jar</pluginJar>
+    <pluginJar>plugins/iccprofileSample-plugin/iccprofileSample-plugin-${project.version}.jar</pluginJar>
   </plugin>
   <plugin enabled="false">
     <name>Image Sample</name>
     <version>${project.version}</version>
     <description>Sample, proof of concept, image plugin. Developed by the veraPDF team.</description>
-    <pluginJar>$INSTALL_PATH/plugins/imageSample-plugin/imageSample-plugin-${project.version}.jar</pluginJar>
+    <pluginJar>plugins/imageSample-plugin/imageSample-plugin-${project.version}.jar</pluginJar>
   </plugin>
   <plugin enabled="false">
     <name>METS metadata extraction Sample</name>
     <version>${project.version}</version>
     <description>Sample, proof of concept, METS metadata extraction plugin. Developed by the veraPDF team.</description>
-    <pluginJar>$INSTALL_PATH/plugins/metsMetadata-plugin/metsMetadata-plugin-${project.version}.jar</pluginJar>
+    <pluginJar>plugins/metsMetadata-plugin/metsMetadata-plugin-${project.version}.jar</pluginJar>
   </plugin>
 </pluginsConfig>

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,24 @@
                 <artifactId>core</artifactId>
                 <version>[1.1.0,1.2.0)</version>
             </dependency>
+
+            <dependency>
+              <groupId>javax.xml.bind</groupId>
+              <artifactId>jaxb-api</artifactId>
+              <version>2.3.1</version>
+            </dependency>
+
+            <dependency>
+              <groupId>com.sun.xml.bind</groupId>
+              <artifactId>jaxb-impl</artifactId>
+              <version>2.3.1</version>
+            </dependency>
+
+            <dependency>
+              <groupId>com.sun.xml.bind</groupId>
+              <artifactId>jaxb-core</artifactId>
+              <version>2.3.0.1</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
- altered plugin paths in config to be relative;
- added explicit `javax.xml.bind` dependencies to Maven; and
- updated Travis build JVMs.

Contributes to veraPDF/veraPDF-library#949 