### PR TITLE
Add an automatic module name to the MANIFEST

### DIFF
--- a/embeddedfileSample-plugin/pom.xml
+++ b/embeddedfileSample-plugin/pom.xml
@@ -63,7 +63,7 @@
                 <configuration>
                     <archive>
                         <manifestEntries>
-                            <Automatic-Module-Name>org.verapdf.embeddedfileSample.plugin</Automatic-Module-Name>
+                            <Automatic-Module-Name>org.verapdf.plugin.embeddedfileSample</Automatic-Module-Name>
                         </manifestEntries>
                     </archive>
                 </configuration>

--- a/embeddedfileSample-plugin/pom.xml
+++ b/embeddedfileSample-plugin/pom.xml
@@ -55,4 +55,20 @@
     </dependency>
   </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>org.verapdf.embeddedfileSample.plugin</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/fontSample-plugin/pom.xml
+++ b/fontSample-plugin/pom.xml
@@ -55,4 +55,20 @@
     </dependency>
   </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>org.verapdf.fontSample.plugin</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/fontSample-plugin/pom.xml
+++ b/fontSample-plugin/pom.xml
@@ -63,7 +63,7 @@
                 <configuration>
                     <archive>
                         <manifestEntries>
-                            <Automatic-Module-Name>org.verapdf.fontSample.plugin</Automatic-Module-Name>
+                            <Automatic-Module-Name>org.verapdf.plugin.fontSample</Automatic-Module-Name>
                         </manifestEntries>
                     </archive>
                 </configuration>

--- a/fontType-plugin/pom.xml
+++ b/fontType-plugin/pom.xml
@@ -39,4 +39,20 @@
     </dependency>
   </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>org.verapdf.fontType.plugin</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/fontType-plugin/pom.xml
+++ b/fontType-plugin/pom.xml
@@ -47,7 +47,7 @@
                 <configuration>
                     <archive>
                         <manifestEntries>
-                            <Automatic-Module-Name>org.verapdf.fontType.plugin</Automatic-Module-Name>
+                            <Automatic-Module-Name>org.verapdf.plugin.fontType</Automatic-Module-Name>
                         </manifestEntries>
                     </archive>
                 </configuration>

--- a/iccdump-plugin/pom.xml
+++ b/iccdump-plugin/pom.xml
@@ -39,4 +39,19 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>org.verapdf.iccdump.plugin</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/iccdump-plugin/pom.xml
+++ b/iccdump-plugin/pom.xml
@@ -47,7 +47,7 @@
                 <configuration>
                     <archive>
                         <manifestEntries>
-                            <Automatic-Module-Name>org.verapdf.iccdump.plugin</Automatic-Module-Name>
+                            <Automatic-Module-Name>org.verapdf.plugin.iccdump</Automatic-Module-Name>
                         </manifestEntries>
                     </archive>
                 </configuration>

--- a/iccprofileSample-plugin/pom.xml
+++ b/iccprofileSample-plugin/pom.xml
@@ -61,7 +61,7 @@
                 <configuration>
                     <archive>
                         <manifestEntries>
-                            <Automatic-Module-Name>org.verapdf.iccprofile.plugin</Automatic-Module-Name>
+                            <Automatic-Module-Name>org.verapdf.plugin.iccprofile</Automatic-Module-Name>
                         </manifestEntries>
                     </archive>
                 </configuration>

--- a/iccprofileSample-plugin/pom.xml
+++ b/iccprofileSample-plugin/pom.xml
@@ -61,7 +61,7 @@
                 <configuration>
                     <archive>
                         <manifestEntries>
-                            <Automatic-Module-Name>org.verapdf.plugin.iccprofile</Automatic-Module-Name>
+                            <Automatic-Module-Name>org.verapdf.plugin.iccprofileSample</Automatic-Module-Name>
                         </manifestEntries>
                     </archive>
                 </configuration>

--- a/iccprofileSample-plugin/pom.xml
+++ b/iccprofileSample-plugin/pom.xml
@@ -53,5 +53,19 @@
       <artifactId>jaxb-core</artifactId>
     </dependency>
   </dependencies>
-
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>org.verapdf.iccprofile.plugin</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/imageSample-plugin/pom.xml
+++ b/imageSample-plugin/pom.xml
@@ -63,7 +63,7 @@
                 <configuration>
                     <archive>
                         <manifestEntries>
-                            <Automatic-Module-Name>org.verapdf.imageSample.plugin</Automatic-Module-Name>
+                            <Automatic-Module-Name>org.verapdf.plugin.imageSample</Automatic-Module-Name>
                         </manifestEntries>
                     </archive>
                 </configuration>

--- a/imageSample-plugin/pom.xml
+++ b/imageSample-plugin/pom.xml
@@ -55,4 +55,20 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>org.verapdf.imageSample.plugin</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/jpylyzer-plugin/pom.xml
+++ b/jpylyzer-plugin/pom.xml
@@ -63,7 +63,7 @@
                 <configuration>
                     <archive>
                         <manifestEntries>
-                            <Automatic-Module-Name>org.verapdf.jpylyzer.plugin</Automatic-Module-Name>
+                            <Automatic-Module-Name>org.verapdf.plugin.jpylyzer</Automatic-Module-Name>
                         </manifestEntries>
                     </archive>
                 </configuration>

--- a/jpylyzer-plugin/pom.xml
+++ b/jpylyzer-plugin/pom.xml
@@ -54,4 +54,20 @@
           <artifactId>jaxb-core</artifactId>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>org.verapdf.jpylyzer.plugin</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/mediaconch/pom.xml
+++ b/mediaconch/pom.xml
@@ -55,4 +55,20 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>org.verapdf.mediaconch.plugin</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/mediaconch/pom.xml
+++ b/mediaconch/pom.xml
@@ -63,7 +63,7 @@
                 <configuration>
                     <archive>
                         <manifestEntries>
-                            <Automatic-Module-Name>org.verapdf.mediaconch.plugin</Automatic-Module-Name>
+                            <Automatic-Module-Name>org.verapdf.plugin.mediaconch</Automatic-Module-Name>
                         </manifestEntries>
                     </archive>
                 </configuration>

--- a/metsMetadata-plugin/pom.xml
+++ b/metsMetadata-plugin/pom.xml
@@ -63,6 +63,17 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>org.verapdf.metsMetadata.plugin</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-assembly-plugin</artifactId>

--- a/metsMetadata-plugin/pom.xml
+++ b/metsMetadata-plugin/pom.xml
@@ -69,7 +69,7 @@
                 <configuration>
                     <archive>
                         <manifestEntries>
-                            <Automatic-Module-Name>org.verapdf.metsMetadata.plugin</Automatic-Module-Name>
+                            <Automatic-Module-Name>org.verapdf.plugin.metsMetadata</Automatic-Module-Name>
                         </manifestEntries>
                     </archive>
                 </configuration>

--- a/ots-plugin/pom.xml
+++ b/ots-plugin/pom.xml
@@ -54,4 +54,20 @@
           <artifactId>jaxb-core</artifactId>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>org.verapdf.ost.plugin</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/ots-plugin/pom.xml
+++ b/ots-plugin/pom.xml
@@ -63,7 +63,7 @@
                 <configuration>
                     <archive>
                         <manifestEntries>
-                            <Automatic-Module-Name>org.verapdf.ost.plugin</Automatic-Module-Name>
+                            <Automatic-Module-Name>org.verapdf.plugin.ots</Automatic-Module-Name>
                         </manifestEntries>
                     </archive>
                 </configuration>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -94,6 +94,17 @@
         </resource>
       </resources>
       <plugins>
+          <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-jar-plugin</artifactId>
+              <configuration>
+                  <archive>
+                      <manifestEntries>
+                          <Automatic-Module-Name>org.verapdf.plugins</Automatic-Module-Name>
+                      </manifestEntries>
+                  </archive>
+              </configuration>
+          </plugin>
         <plugin>
            <artifactId>maven-assembly-plugin</artifactId>
            <version>2.2.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.verapdf</groupId>
         <artifactId>verapdf-parent</artifactId>
-        <version>1.29.1</version>
+        <version>1.29.6</version>
     </parent>
 
     <groupId>org.verapdf.plugins</groupId>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added explicit Automatic-Module-Name entries to JAR manifests across multiple plugins to improve module naming and compatibility.
  * Updated project parent Maven version to 1.29.6.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->